### PR TITLE
adjust port if websocket is used

### DIFF
--- a/scripts/groovy/analyse_dataset_and_save_rois.groovy
+++ b/scripts/groovy/analyse_dataset_and_save_rois.groovy
@@ -94,6 +94,14 @@ def get_image_ids(gateway, ctx, dataset_id) {
     return image_ids
 }
 
+def get_port(HOST) {
+    port = 4064
+    // check if websockets is used
+    if (HOST.startsWith("ws")) {
+        port = 443
+    }
+    return port
+}
 
 def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     "Open the image using the Bio-Formats Importer"
@@ -104,7 +112,7 @@ def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     options.append("\nuser=")
     options.append(USERNAME.trim())
     options.append("\nport=")
-    options.append(443)
+    options.append(get_port(HOST))
     options.append("\npass=")
     options.append(PASSWORD.trim())
     options.append("\ngroupID=")

--- a/scripts/groovy/analyse_dataset_ilastik.groovy
+++ b/scripts/groovy/analyse_dataset_ilastik.groovy
@@ -84,6 +84,15 @@ def get_images(gateway, ctx, dataset_id) {
     return browse.getImagesForDatasets(ctx, ids)
 }
 
+def get_port(HOST) {
+    port = 4064
+    // check if websockets is used
+    if (HOST.startsWith("ws")) {
+        port = 443
+    }
+    return port
+}
+
 def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     "Open the image using the Bio-Formats Importer"
 
@@ -93,7 +102,7 @@ def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     options.append("\nuser=")
     options.append(USERNAME.trim())
     options.append("\nport=")
-    options.append(443)
+    options.append(get_port(HOST))
     options.append("\npass=")
     options.append(PASSWORD.trim())
     options.append("\ngroupID=")

--- a/scripts/groovy/analyse_dataset_save_rois_and_summary_table.groovy
+++ b/scripts/groovy/analyse_dataset_save_rois_and_summary_table.groovy
@@ -110,6 +110,15 @@ def get_images(gateway, ctx, dataset_id) {
 }
 
 
+def get_port(HOST) {
+    port = 4064
+    // check if websockets is used
+    if (HOST.startsWith("ws")) {
+        port = 443
+    }
+    return port
+}
+
 def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     "Open the image using the Bio-Formats Importer"
 
@@ -119,7 +128,7 @@ def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     options.append("\nuser=")
     options.append(USERNAME.trim())
     options.append("\nport=")
-    options.append(443)
+    options.append(get_port(HOST))
     options.append("\npass=")
     options.append(PASSWORD.trim())
     options.append("\ngroupID=")

--- a/scripts/groovy/analyse_image_map_annotation.groovy
+++ b/scripts/groovy/analyse_image_map_annotation.groovy
@@ -85,6 +85,15 @@ def connect_to_omero() {
 
 }
 
+def get_port(HOST) {
+    port = 4064
+    // check if websockets is used
+    if (HOST.startsWith("ws")) {
+        port = 443
+    }
+    return port
+}
+
 def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     "Open the image using the Bio-Formats Importer"
 
@@ -94,7 +103,7 @@ def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     options.append("\nuser=")
     options.append(USERNAME.trim())
     options.append("\nport=")
-    options.append(443)
+    options.append(get_port(HOST))
     options.append("\npass=")
     options.append(PASSWORD.trim())
     options.append("\ngroupID=")

--- a/scripts/groovy/analyse_particles_for_another_user.groovy
+++ b/scripts/groovy/analyse_particles_for_another_user.groovy
@@ -118,6 +118,15 @@ def switch_security_context(ctx, target_user) {
 }
 
 
+def get_port(HOST) {
+    port = 4064
+    // check if websockets is used
+    if (HOST.startsWith("ws")) {
+        port = 443
+    }
+    return port
+}
+
 def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     "Open the image using the Bio-Formats Importer"
 
@@ -127,7 +136,7 @@ def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     options.append("\nuser=")
     options.append(USERNAME.trim())
     options.append("\nport=")
-    options.append(443)
+    options.append(get_port(HOST))
     options.append("\npass=")
     options.append(PASSWORD.trim())
     options.append("\ngroupID=")

--- a/scripts/groovy/background_subtract_batch.groovy
+++ b/scripts/groovy/background_subtract_batch.groovy
@@ -79,6 +79,15 @@ def connect_to_omero() {
 
 }
 
+def get_port(HOST) {
+    port = 4064
+    // check if websockets is used
+    if (HOST.startsWith("ws")) {
+        port = 443
+    }
+    return port
+}
+
 def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     "Open the image using the Bio-Formats Importer"
 
@@ -88,7 +97,7 @@ def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     options.append("\nuser=")
     options.append(USERNAME.trim())
     options.append("\nport=")
-    options.append(443)
+    options.append(get_port(HOST))
     options.append("\npass=")
     options.append(PASSWORD.trim())
     options.append("\ngroupID=")

--- a/scripts/groovy/crop_rectangle_from_image.groovy
+++ b/scripts/groovy/crop_rectangle_from_image.groovy
@@ -73,7 +73,15 @@ def connect_to_omero() {
     gateway = new Gateway(simpleLogger)
     gateway.connect(credentials)
     return gateway
+}
 
+def get_port(HOST) {
+    port = 4064
+    // check if websockets is used
+    if (HOST.startsWith("ws")) {
+        port = 443
+    }
+    return port
 }
 
 def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
@@ -85,7 +93,7 @@ def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     options.append("\nuser=")
     options.append(USERNAME.trim())
     options.append("\nport=")
-    options.append(443)
+    options.append(get_port(HOST))
     options.append("\npass=")
     options.append(PASSWORD.trim())
     options.append("\ngroupID=")

--- a/scripts/groovy/idr0021.groovy
+++ b/scripts/groovy/idr0021.groovy
@@ -173,6 +173,15 @@ def get_channel_wavelength(gateway, ctx, image_id, dataset_name) {
 }
 
 
+def get_port(HOST) {
+    port = 4064
+    // check if websockets is used
+    if (HOST.startsWith("ws")) {
+        port = 443
+    }
+    return port
+}
+
 def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     "Open the image using the Bio-Formats Importer"
 
@@ -182,7 +191,7 @@ def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     options.append("\nuser=")
     options.append(USERNAME.trim())
     options.append("\nport=")
-    options.append(443)
+    options.append(get_port(HOST))
     options.append("\npass=")
     options.append(PASSWORD.trim())
     options.append("\ngroupID=")

--- a/scripts/groovy/open_omero_image_no_download.groovy
+++ b/scripts/groovy/open_omero_image_no_download.groovy
@@ -60,6 +60,15 @@ def connect_to_omero() {
 
 }
 
+def get_port(HOST) {
+    port = 4064
+    // check if websockets is used
+    if (HOST.startsWith("ws")) {
+        port = 443
+    }
+    return port
+}
+
 def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     "Open the image using the Bio-Formats Importer"
 
@@ -69,7 +78,7 @@ def open_image_plus(HOST, USERNAME, PASSWORD, group_id, image_id) {
     options.append("\nuser=")
     options.append(USERNAME.trim())
     options.append("\nport=")
-    options.append(443)
+    options.append(get_port(HOST))
     options.append("\npass=")
     options.append(PASSWORD.trim())
     options.append("\ngroupID=")


### PR DESCRIPTION
Use 443 only when websocket is used
The current set-up can be confusing
cc @pwalczysko 
see https://github.com/ome/omero-guide-fiji/issues/15