### PR TITLE
Improve the manual workflow description

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,10 +5,10 @@ Description
 -----------
 
 `Fiji <https://imagej.net/Fiji>`__ is a free open-source image processing package based on
-ImageJ. The following workflow should how to
+ImageJ. The following workflow shows how to
 install the OMERO plugin for Fiji and ImageJ.
 
-The OMERO plugin does not have yet and update site.
+The OMERO plugin does not have an update site yet.
 
 Setup step-by-step
 ------------------
@@ -16,16 +16,16 @@ Setup step-by-step
 We assume that you have already Fiji/ImageJ installed locally.
 
 In this section, we will cover the steps required to install the
-OMERO.imagej plugin for Fiji. If you wish to install it for ImageJ,
+OMERO plugin for Fiji. If you wish to install it for ImageJ,
 an additional step is needed.
 
-We first describe how the common installation steps for ImageJ and Fiji.
+We first describe the common installation steps for ImageJ and Fiji.
 We then describe how to install the *Bio-Formats Package* for ImageJ.
 
-Installing the OMERO.imagej plugin also adds the dependencies
+Installing the OMERO plugin in Fiji also adds the dependencies
 required to connect to OMERO using the Script Editor of Fiji.
 
-Installation of the OMERO.imagej plugin for Fiji and ImageJ, the
+Installation of the OMERO plugin for Fiji and ImageJ, the
 common steps:
 
 -  Find the Plugins folder of your Fiji application and check if it contains any old omero_ij-5.x.x-all.jar file(s) or OMERO.imagej-5.x.x folder(s). Remove any such jar files or folders from the Plugins folder.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,7 +35,7 @@ common steps:
 
 .. image:: images/setup1.png
 
--  For recent plugin versions (5.5.7 and higher): Note where you the downloaded the omero_ij-5.x.x-all.jar file. Copy that file into the *plugins* folder of Fiji.
+-  For recent plugin versions (5.5.7 and higher): Note where you downloaded the omero_ij-5.x.x-all.jar file. Copy that file into the *plugins* folder of Fiji.
 
 -  For plugin versions lower than 5.5.7: Extract the downloaded .zip archive. Remember where you extracted it to.
 

--- a/docs/manual_analysis.rst
+++ b/docs/manual_analysis.rst
@@ -87,7 +87,7 @@ In this first example we show how to open an OMERO image in Fiji, draw ROIs, mea
 
    .. image:: images/manual4.png
 
-#. Go back to OMERO.web, in the right-hand panel.
+#. Go to OMERO.web and log in.
 
 #. Select the image opened in Fiji/ImageJ.
 
@@ -104,7 +104,7 @@ import the cropped image back to OMERO as OME-TIFF.
 In this example we assume that the user is already logged in. If this is
 not the case, go back to the first step of Example 1.
 
-#. Select the *A-Fiji-dataset* Dataset.
+#. Select a dataset, for example the *A-Fiji-dataset* Dataset.
 
 #. Double-click on a thumbnail or on an Image in the left-hand tree to open an Image in Fiji/ImageJ.
 
@@ -116,13 +116,13 @@ not the case, go back to the first step of Example 1.
 
 #. Go to *Plugins > OMERO > Save Image(s) To OMERO*.
 
-#. An Import dialog (specific to the OMERO Fiji/ImageJ plugin) will pop up.
+#. An Import dialog will pop up.
 
    .. image:: images/manual5.png
 
-#. Check that the option *Add Image from current window* is selected
+#. Check that the option *Add Image from current window* is selected.
 
-#. Select where to import the cropped Image e.g. **A-Fiji-dataset** Dataset.
+#. Select where to import the cropped Image, for example an existing Dataset, e.g. *A-Fiji-dataset* Dataset. You can also select *New From Folder* option which will create a new Dataset named with the name of the image you opened from OMERO to Fiji. In case you select *No Dataset* option, the new image will be displayed in the *Orphaned Images* folder in OMERO.
 
 #. Click *Add to the Queue* button.
 

--- a/docs/manual_analysis.rst
+++ b/docs/manual_analysis.rst
@@ -73,7 +73,7 @@ In this first example we show how to open an OMERO image in Fiji, draw ROIs, mea
 
 #. Move to another channel, using the *c slider*.
 
-#. Draw other shapes if desired. Add drawing a shape. Click *Add [t]* to add it to the ROI Manager.
+#. Draw other shapes if desired. Click *Add [t]* to add them to the ROI Manager.
 
 #. When done with the drawing, click the button *Measure* in the ROI Manager.
 
@@ -81,7 +81,7 @@ In this first example we show how to open an OMERO image in Fiji, draw ROIs, mea
 
 #. To save the ROI and the measurement back to OMERO, go to *Plugins > OMERO > Save ROIs To OMERO*.
 
-#. In the dialog popping up, under the *Save* section select *ROI and Measurements*.
+#. In the dialog popping up, under the *Save* section select *ROI* and *Measurements*.
 
 #. The measurements are saved back to OMERO as a CSV file and linked to the Image.
 

--- a/docs/manual_analysis.rst
+++ b/docs/manual_analysis.rst
@@ -73,7 +73,7 @@ In this first example we show how to open an OMERO image in Fiji, draw ROIs, mea
 
 #. Move to another channel, using the *c slider*.
 
-#. Draw other shapes if desired. Add drawing a shape. Click *Add [t]* to add it to the Manager.
+#. Draw other shapes if desired. Add drawing a shape. Click *Add [t]* to add it to the ROI Manager.
 
 #. When done with the drawing, click the button *Measure* in the ROI Manager.
 
@@ -81,7 +81,7 @@ In this first example we show how to open an OMERO image in Fiji, draw ROIs, mea
 
 #. To save the ROI and the measurement back to OMERO, go to *Plugins > OMERO > Save ROIs To OMERO*.
 
-#. In the dialog popping up, under the *Save* section select ROI and Measurements.
+#. In the dialog popping up, under the *Save* section select *ROI and Measurements*.
 
 #. The measurements are saved back to OMERO as a CSV file and linked to the Image.
 
@@ -91,7 +91,7 @@ In this first example we show how to open an OMERO image in Fiji, draw ROIs, mea
 
 #. Select the image opened in Fiji/ImageJ.
 
-#. Check that there is a new CSV file under the Attachments harmonica.
+#. Check that there is a new CSV file under the *Attachments* harmonica.
 
 #. Open the image in OMERO.iviewer to the see the ROIs and make sure that you can interact with them.
 
@@ -122,7 +122,7 @@ not the case, go back to the first step of Example 1.
 
 #. Check that the option *Add Image from current window* is selected.
 
-#. Select where to import the cropped Image, for example an existing Dataset, e.g. *A-Fiji-dataset* Dataset. You can also select *New From Folder* option which will create a new Dataset named with the name of the image you opened from OMERO to Fiji. In case you select *No Dataset* option, the new image will be displayed in the *Orphaned Images* folder in OMERO.
+#. Select where to import the cropped Image, for example an existing Dataset, e.g. *A-Fiji-dataset*. You can also select *New From Folder* option which will create a new Dataset named with the name of the image you opened from OMERO to Fiji. In case you select *No Dataset* option, the new image will be displayed in the *Orphaned Images* folder in OMERO.
 
 #. Click *Add to the Queue* button.
 


### PR DESCRIPTION
As a follow-up to the recent workshop, improve the manual Fiji workflow (Crop)

 - do not assume that the user has access to A-Fiji-dataset
 - explain behaviour when selecting "New From Folder" option
 - explain behaviour when selecting "No Dataset" option

Also, fixing a minor imprecise formulation in the ROIs and Measurements section.
Also, fix typos in the Installation of the OMERO plugin for Fiji doc.
