### PR TITLE
Vnc

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,14 +2,10 @@ name: base
 channels:
   - conda-forge
   - ome
-  - manics
 dependencies:
   - beakerx
   - pip
-  - websockify=0.9.0
+  - websockify
   - pyimagej
   - omero-py
-  - pip:
-    # Recent jupyter-server-proxy to load vnc_lite.html instead of /
-    # https://github.com/jupyterhub/jupyter-server-proxy/pull/151
-    - https://github.com/jupyterhub/jupyter-server-proxy/archive/0e67e1afd0bab1342443f13bd147a2f8c682e9e0.zip
+  - jupyter-server-proxy

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -21,7 +21,7 @@ sed -i.bak \
     noVNC-1.1.0/vnc_lite.html
 
 # Install tigervnc
-curl -sSfL 'https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc-1.9.0.x86_64.tar.gz' | tar -zxf - --strip=2
+curl -sSfL 'https://sourceforge.net/projects/tigervnc/files/stable/1.9.0/tigervnc-1.9.0.x86_64.tar.gz' | tar -zxf - --strip=2
 
 
 cp $REPO_DIR/jupyter_desktop/share/xstartup .


### PR DESCRIPTION
This PR fixes the installation of novnc. The file is no longer available at https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc-1.9.0.x86_64.tar.gz.
This stops working over the weekend

This PR also installed dependencies from conda-forge channel

* Check that the desktop can be started.
* Check a notebook e.g. crop notebook.


cc @pwalczysko 